### PR TITLE
Fix Quagga build when using install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ fi
 CWD=`dirname $0`
 SCRIPT=$(readlink -f $0)
 DIR=`dirname $SCRIPT`
-BIN=(awk -F "=" '/quagga_path=/ { print $NF }' $DIR/fibbingnode/res/default.cfg)
+BIN=`(awk -F "=" '/quagga_path=/ { print $NF }' $DIR/fibbingnode/res/default.cfg)`
 
 quagga() {
     if ! getent group quagga ; then


### PR DESCRIPTION
Quagga is not properly built when using install.sh because awk command
is not working correctly in the script.
